### PR TITLE
Fix cleanup of teams and services, and codecov report uploading

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -58,9 +58,4 @@ jobs:
         DD_TEST_CLIENT_APP_KEY: $(datadogAPPKey)
         DD_TRACE_ANALYTICS_ENABLED: "true"
         RECORD: "none"
-    - script: |
-        bash <(curl -s https://codecov.io/bash) -F integration -v
-
-      displayName: Upload to codecov.io
-      env:
         CODECOV_TOKEN: $(codecovToken)

--- a/features/step_definitions/request.rb
+++ b/features/step_definitions/request.rb
@@ -83,7 +83,7 @@ module APIWorld
   end
 
   def undo_create_incident(response)
-    configuration.config.unstable_operations[:delete_incident] = true
+    configuration.unstable_operations[:delete_incident] = true
     api_instance = DatadogAPIClient::V2::IncidentsApi.new api_client
     api_instance.delete_incident(response[0].data.id)
   end
@@ -104,7 +104,7 @@ module APIWorld
   end
 
   def undo_create_incident_service(response)
-    configuration.config.unstable_operations[:delete_incident_service] = true
+    configuration.unstable_operations[:delete_incident_service] = true
     api_instance = DatadogAPIClient::V2::IncidentServicesApi.new api_client
     api_instance.delete_incident_service(response[0].data.id)
   end


### PR DESCRIPTION
The ruby gem takes care of uploading, so no need to do it manually