### PR TITLE
Expose user-friendly `api_key=`/`application_key=` setters for authentication

### DIFF
--- a/features/step_definitions/request.rb
+++ b/features/step_definitions/request.rb
@@ -76,10 +76,10 @@ module APIWorld
 
     # make sure we have a fresh instance of API client and configuration
     given_api = Object.const_get("DatadogAPIClient::V#{api_version}")
-    given_configuration = given_api.const_get("Configuration").new
-    given_configuration.api_key['apiKeyAuth'] = ENV["DD_TEST_CLIENT_API_KEY"]
-    given_configuration.api_key['appKeyAuth'] = ENV["DD_TEST_CLIENT_APP_KEY"]
-    given_api_client = given_api.const_get("ApiClient").new given_configuration
+    given_configuration = given_api::Configuration.new
+    given_configuration.api_key = ENV["DD_TEST_CLIENT_API_KEY"]
+    given_configuration.app_key = ENV["DD_TEST_CLIENT_APP_KEY"]
+    given_api_client = given_api::ApiClient.new given_configuration
     given_api_instance = api.const_get("#{api_name}Api").new given_api_client
     method = given_api_instance.method("#{operation_name}_with_http_info".to_sym)
 
@@ -115,11 +115,11 @@ World(APIWorld)
 
 
 Given('a valid "apiKeyAuth" key in the system') do
-  configuration.api_key['apiKeyAuth'] = ENV["DD_TEST_CLIENT_API_KEY"]
+  configuration.api_key = ENV["DD_TEST_CLIENT_API_KEY"]
 end
 
 Given('a valid "appKeyAuth" key in the system') do
-  configuration.api_key['appKeyAuth'] = ENV["DD_TEST_CLIENT_APP_KEY"]
+  configuration.app_key = ENV["DD_TEST_CLIENT_APP_KEY"]
 end
 
 Given(/^an instance of "([^"]+)" API$/) do |api_name|

--- a/features/step_definitions/request.rb
+++ b/features/step_definitions/request.rb
@@ -78,7 +78,7 @@ module APIWorld
     given_api = Object.const_get("DatadogAPIClient::V#{api_version}")
     given_configuration = given_api::Configuration.new
     given_configuration.api_key = ENV["DD_TEST_CLIENT_API_KEY"]
-    given_configuration.app_key = ENV["DD_TEST_CLIENT_APP_KEY"]
+    given_configuration.application_key = ENV["DD_TEST_CLIENT_APP_KEY"]
     given_api_client = given_api::ApiClient.new given_configuration
     given_api_instance = api.const_get("#{api_name}Api").new given_api_client
     method = given_api_instance.method("#{operation_name}_with_http_info".to_sym)
@@ -119,7 +119,7 @@ Given('a valid "apiKeyAuth" key in the system') do
 end
 
 Given('a valid "appKeyAuth" key in the system') do
-  configuration.app_key = ENV["DD_TEST_CLIENT_APP_KEY"]
+  configuration.application_key = ENV["DD_TEST_CLIENT_APP_KEY"]
 end
 
 Given(/^an instance of "([^"]+)" API$/) do |api_name|

--- a/lib/datadog_api_client.rb
+++ b/lib/datadog_api_client.rb
@@ -1,5 +1,4 @@
 require 'datadog_api_client/version'
 require 'datadog_api_client/v1'
 require 'datadog_api_client/v2'
-
-
+require 'datadog_api_client/api_key_configuration'

--- a/lib/datadog_api_client/api_key_configuration.rb
+++ b/lib/datadog_api_client/api_key_configuration.rb
@@ -1,8 +1,8 @@
 require 'datadog_api_client/v1'
 require 'datadog_api_client/v2'
 
-# Extend the automatically-generated client configuration classes with a user-friendly authentication configuration,
-# hiding the original #api_key method
+# Extend the automatically-generated client configuration classes with a user-friendly
+# authentication configuration, hiding the original #api_key method.
 
 module DatadogAPIClient::V1
   class Configuration

--- a/lib/datadog_api_client/api_key_configuration.rb
+++ b/lib/datadog_api_client/api_key_configuration.rb
@@ -9,11 +9,11 @@ module DatadogAPIClient::V1
     private :api_key # Make original getter private
 
     def api_key=(api_key)
-      self.api_key['apiKeyAuth'] = api_key
+      @api_key['apiKeyAuth'] = api_key
     end
 
     def application_key=(app_key)
-      self.api_key['appKeyAuth'] = app_key
+      @api_key['appKeyAuth'] = app_key
     end
   end
 end
@@ -23,11 +23,11 @@ module DatadogAPIClient::V2
     private :api_key # Make original getter private
 
     def api_key=(api_key)
-      self.api_key['apiKeyAuth'] = api_key
+      @api_key['apiKeyAuth'] = api_key
     end
 
     def application_key=(app_key)
-      self.api_key['appKeyAuth'] = app_key
+      @api_key['appKeyAuth'] = app_key
     end
   end
 end

--- a/lib/datadog_api_client/api_key_configuration.rb
+++ b/lib/datadog_api_client/api_key_configuration.rb
@@ -12,7 +12,7 @@ module DatadogAPIClient::V1
       self.api_key['apiKeyAuth'] = api_key
     end
 
-    def app_key=(app_key)
+    def application_key=(app_key)
       self.api_key['appKeyAuth'] = app_key
     end
   end
@@ -26,7 +26,7 @@ module DatadogAPIClient::V2
       self.api_key['apiKeyAuth'] = api_key
     end
 
-    def app_key=(app_key)
+    def application_key=(app_key)
       self.api_key['appKeyAuth'] = app_key
     end
   end

--- a/lib/datadog_api_client/api_key_configuration.rb
+++ b/lib/datadog_api_client/api_key_configuration.rb
@@ -1,0 +1,33 @@
+require 'datadog_api_client/v1'
+require 'datadog_api_client/v2'
+
+# Extend the automatically-generated client configuration classes with a user-friendly authentication configuration,
+# hiding the original #api_key method
+
+module DatadogAPIClient::V1
+  class Configuration
+    private :api_key # Make original getter private
+
+    def api_key=(api_key)
+      self.api_key[:apiKeyAuth] = api_key
+    end
+
+    def app_key=(app_key)
+      self.api_key[:appKeyAuth] = app_key
+    end
+  end
+end
+
+module DatadogAPIClient::V2
+  class Configuration
+    private :api_key # Make original getter private
+
+    def api_key=(api_key)
+      self.api_key[:apiKeyAuth] = api_key
+    end
+
+    def app_key=(app_key)
+      self.api_key[:appKeyAuth] = app_key
+    end
+  end
+end

--- a/lib/datadog_api_client/api_key_configuration.rb
+++ b/lib/datadog_api_client/api_key_configuration.rb
@@ -9,11 +9,11 @@ module DatadogAPIClient::V1
     private :api_key # Make original getter private
 
     def api_key=(api_key)
-      self.api_key[:apiKeyAuth] = api_key
+      self.api_key['apiKeyAuth'] = api_key
     end
 
     def app_key=(app_key)
-      self.api_key[:appKeyAuth] = app_key
+      self.api_key['appKeyAuth'] = app_key
     end
   end
 end
@@ -23,11 +23,11 @@ module DatadogAPIClient::V2
     private :api_key # Make original getter private
 
     def api_key=(api_key)
-      self.api_key[:apiKeyAuth] = api_key
+      self.api_key['apiKeyAuth'] = api_key
     end
 
     def app_key=(app_key)
-      self.api_key[:appKeyAuth] = app_key
+      self.api_key['appKeyAuth'] = app_key
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,11 +99,11 @@ RSpec.configure do |config|
     m = example.metadata[:file_path].match /spec\/v(?<version>\d+)\/.*/
     @api_version = m[:version]
     api = Object.const_get("DatadogAPIClient::V#{@api_version}")
-    @configuration = api.const_get("Configuration").new
-    @configuration.api_key["apiKeyAuth"] = ENV["DD_TEST_CLIENT_API_KEY"]
-    @configuration.api_key["appKeyAuth"] = ENV["DD_TEST_CLIENT_APP_KEY"]
-    @configuration.debugging = (!ENV["DEBUG"].nil? and ENV["DEBUG"] != false)
-    @api_client = api.const_get("ApiClient").new @configuration
+    @configuration = api::Configuration.new
+    @configuration.api_key = ENV["DD_TEST_CLIENT_API_KEY"]
+    @configuration.app_key = ENV["DD_TEST_CLIENT_APP_KEY"]
+    @configuration.debugging = (!ENV["DEBUG"].nil? and ENV["DEBUG"] != "false")
+    @api_client = api::ApiClient.new @configuration
   end
 
   config.after(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,7 +101,7 @@ RSpec.configure do |config|
     api = Object.const_get("DatadogAPIClient::V#{@api_version}")
     @configuration = api::Configuration.new
     @configuration.api_key = ENV["DD_TEST_CLIENT_API_KEY"]
-    @configuration.app_key = ENV["DD_TEST_CLIENT_APP_KEY"]
+    @configuration.application_key = ENV["DD_TEST_CLIENT_APP_KEY"]
     @configuration.debugging = (!ENV["DEBUG"].nil? and ENV["DEBUG"] != "false")
     @api_client = api::ApiClient.new @configuration
   end


### PR DESCRIPTION
As discussed this is a prototype of how we could provide a nicer behavior for authentication configuration without needing to touch the automatically-generated API clients.