### PR TITLE
Remove unstable warnings in tests

### DIFF
--- a/features/step_definitions/request.rb
+++ b/features/step_definitions/request.rb
@@ -102,7 +102,9 @@ module APIWorld
     undo_builder = build_undo_for(operation_name, given_api_instance)
 
     # enable unstable operation
-    given_configuration.unstable_operations[operation_name.to_sym] = true
+    if given_configuration.unstable_operations.has_key?(operation_name.to_sym)
+      given_configuration.unstable_operations[operation_name.to_sym] = true
+    end
 
     # perform operation
     args = operation["parameters"].map do |p|


### PR DESCRIPTION
By setting the unstable flag unconditionally we generated lots of
warnings.