### PR TITLE
Support latest cucumber release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'activesupport'
   gem 'cucumber'
   gem 'gem-release'
   # gem 'ddtrace'


### PR DESCRIPTION
We were not explicitly depending on active_support, this breaks with cucumber 7 it seems.