### PR TITLE
ci: use named caches for bundler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+          # modify repository secret when there are problems with installing gems
+          cache-version: ${{ secrets.CACHE_VERSION }}
       - name: Test
         run: ./run-tests.sh
         shell: bash

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           ruby-version: 2.7
           bundler-cache: true
+          cache-version: ${{ secrets.CACHE_VERSION }}
       - name: Install deps
         run: bundle install
       - name: Run integration tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,3 +36,8 @@ By default integration tests use recorded API responses stored in cassettes. To 
 **IMPORTANT**:
 When creating a PR that adds or updates a test, __never__ commit
 generated code, only commit test files being updated and any updated cassettes.
+
+### CI
+
+In rare ocassions, the test suite may fail due to a corrupted cache in `ruby/setup-ruby` action.
+Please update `CACHE_VERSION` secret in https://github.com/DataDog/datadog-api-client-ruby/settings/secrets/actions/CACHE_VERSION with a new unique value.


### PR DESCRIPTION
https://github.com/ruby/setup-ruby#dealing-with-a-corrupted-cache