### PR TITLE
Add submitMetrics example

### DIFF
--- a/examples/v1/metrics/SubmitMetrics.rbbeta
+++ b/examples/v1/metrics/SubmitMetrics.rbbeta
@@ -1,6 +1,6 @@
 require 'datadog_api_client'
 api_instance = DatadogAPIClient::V1::MetricsAPI.new
-body = DatadogAPIClient::V1::MetricsPayload.new({series: [DatadogAPIClient::V1::Series.new({metric: 'system.load.1', points: [[Time.now.to_i.to_f, 3.56]]})]}) # MetricsPayload |
+body = DatadogAPIClient::V1::MetricsPayload.new({series: [DatadogAPIClient::V1::Series.new({metric: 'system.load.1', points: [[Time.now.to_f, 3.56]]})]}) # MetricsPayload |
 opts = {
   content_encoding: DatadogAPIClient::V1::MetricContentEncoding::DEFLATE
 }


### PR DESCRIPTION
Add a static example to override the generated one for the submitMetrics endpoint.