### PR TITLE
Update the metics query pointlist type

### DIFF
--- a/lib/datadog_api_client/v1/models/metrics_query_metadata.rb
+++ b/lib/datadog_api_client/v1/models/metrics_query_metadata.rb
@@ -95,7 +95,7 @@ module DatadogAPIClient::V1
         :'interval' => :'Integer',
         :'length' => :'Integer',
         :'metric' => :'String',
-        :'pointlist' => :'Array<Array>',
+        :'pointlist' => :'Array<Array<Float>>',
         :'query_index' => :'Integer',
         :'scope' => :'String',
         :'start' => :'Integer',


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely 
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. 
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

:wave: Hi,

We recently notice tha the [`dogapi`](https://github.com/DataDog/dogapi-rb) gem has been marked as legacy, so we are trying to adopt the new ruby datadog client, but I have a blocking error using the [query-timeseries-points](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint.

Here the error: 
```
> client.query_metrics(1636822108, 1639414144, "metric.name{tag: value}")
ETHON: Libcurl initialized
ETHON: performed EASY effective_url=https://api.datadoghq.com/api/v1/query?from=1636822108&to=1639414144&query=metric.name%7Btag%3Avalue%7D response_code=200 return_code=ok total_time=0.673536
NoMethodError: undefined method `build_from_hash' for Array:Class
from /Users/xxx/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/datadog_api_client-1.0.0/lib/datadog_api_client/v1/models/metrics_query_metadata.rb:301:in `_deserialize'
```

It looks like the response is ok (200) but there is an issue in the `deserialize` method.

I've compared the response body with the previous implementation (using `dogapi` gem) and both are identical:
```
"{\"status\":\"ok\",\"resp_version\":1,\"series\":[{\"end\":1639483199000,\"attributes\":{},\"metric\":\"metric.name\",\"interval\":14400,\"tag_set\":[],\"start\":1636963200000,\"length\":118,\"query_index\":0,\"aggr\":null,\"scope\":\"tag: value\",\"pointlist\":[[1636963200000.0,66.0],[1636977600000.0,66.0],[1636992000000.0,66.0],[1637006400000.0,66.0],[1637020800000.0,66.0],[1637035200000.0,66.0],[1637049600000.0,66.0],[1637064000000.0,66.0],[1637078400000.0,66.0],[1637092800000.0,66.0],[1637107200000.0,66.0],[1637121600000.0,66.0],[1637136000000.0,66.0],[1637150400000.0,66.0],[1637164800000.0,66.0],[1637179200000.0,66.0],
[...],
[1638979200000.0,66.0],[1638993600000.0,66.0],[1639008000000.0,66.0],[1639022400000.0,66.0],[1639036800000.0,66.0],[1639051200000.0,66.0],[1639267200000.0,66.0],[1639339200000.0,66.0],[1639353600000.0,66.0],[1639368000000.0,66.0],[1639382400000.0,66.0],[1639396800000.0,66.0],[1639411200000.0,66.0],[1639425600000.0,66.0],[1639440000000.0,66.5],[1639454400000.0,67.0],[1639468800000.0,67.0]],\"expression\":\"metric.name{tag: value}\",\"unit\":null,\"display_name\":\"metric.name\"}],\"to_date\":1639475622000,\"query\":\"metric.name{tag: value}\",\"message\":\"\",\"res_type\":\"time_series\",\"times\":[],\"from_date\":1636883616000,\"group_by\":[],\"values\":[]}"
```

Checking how the `deserialize` is done in the `dogapi` gem, it looks like use [`multi_json`](https://github.com/intridea/multi_json). The `datadog_api_client` doesn't use it and it has a method for it. See [`deserialize` method](https://github.com/DataDog/datadog-api-client-ruby/blob/master/lib/datadog_api_client/v1/models/metrics_query_metadata.rb#L290)

Checking the implementation and the datadog response, we think the issue is how the [attribute type mapping](https://github.com/DataDog/datadog-api-client-ruby/blob/master/lib/datadog_api_client/v1/models/metrics_query_metadata.rb#L88-L105) is defined, in concrete, how the `:pointlist` is mapped. This PR updates it to mach the response we get from Datadog.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist
Please check relevant items below:
- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.


- [ ] This PR does not rely on API client schema changes.
    - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes. 
