### PR TITLE
Enable header matching in tests

### DIFF
--- a/.generator/src/generator/templates/api_client.j2
+++ b/.generator/src/generator/templates/api_client.j2
@@ -25,7 +25,6 @@ module {{ module_name }}::{{ version|upper }}
       @config = config
       @user_agent = "#{{ '{' }}{{ module_name }}::USER_AGENT}"
       @default_headers = {
-        'Content-Type' => 'application/json',
         'User-Agent' => @user_agent
       }
       @default_headers['Accept-Encoding'] = 'gzip' if @config.compress
@@ -329,10 +328,7 @@ module {{ module_name }}::{{ version|upper }}
     # @param [Array] accepts array for Accept
     # @return [String] the Accept header (e.g. application/json)
     def select_header_accept(accepts)
-      return nil if accepts.nil? || accepts.empty?
-      # use JSON when present, otherwise use all of the provided
-      json_accept = accepts.find { |s| json_mime?(s) }
-      json_accept || accepts.join(',')
+      accepts.join(', ')
     end
 
     # Return Content-Type header based on an array of content types provided.

--- a/.generator/src/generator/templates/api_client.j2
+++ b/.generator/src/generator/templates/api_client.j2
@@ -328,6 +328,7 @@ module {{ module_name }}::{{ version|upper }}
     # @param [Array] accepts array for Accept
     # @return [String] the Accept header (e.g. application/json)
     def select_header_accept(accepts)
+      return nil if accepts.nil? || accepts.empty?
       accepts.join(', ')
     end
 

--- a/lib/datadog_api_client/v1/api_client.rb
+++ b/lib/datadog_api_client/v1/api_client.rb
@@ -36,7 +36,6 @@ module DatadogAPIClient::V1
       @config = config
       @user_agent = "#{DatadogAPIClient::USER_AGENT}"
       @default_headers = {
-        'Content-Type' => 'application/json',
         'User-Agent' => @user_agent
       }
       @default_headers['Accept-Encoding'] = 'gzip' if @config.compress
@@ -340,10 +339,7 @@ module DatadogAPIClient::V1
     # @param [Array] accepts array for Accept
     # @return [String] the Accept header (e.g. application/json)
     def select_header_accept(accepts)
-      return nil if accepts.nil? || accepts.empty?
-      # use JSON when present, otherwise use all of the provided
-      json_accept = accepts.find { |s| json_mime?(s) }
-      json_accept || accepts.join(',')
+      accepts.join(', ')
     end
 
     # Return Content-Type header based on an array of content types provided.

--- a/lib/datadog_api_client/v1/api_client.rb
+++ b/lib/datadog_api_client/v1/api_client.rb
@@ -339,6 +339,7 @@ module DatadogAPIClient::V1
     # @param [Array] accepts array for Accept
     # @return [String] the Accept header (e.g. application/json)
     def select_header_accept(accepts)
+      return nil if accepts.nil? || accepts.empty?
       accepts.join(', ')
     end
 

--- a/lib/datadog_api_client/v2/api_client.rb
+++ b/lib/datadog_api_client/v2/api_client.rb
@@ -36,7 +36,6 @@ module DatadogAPIClient::V2
       @config = config
       @user_agent = "#{DatadogAPIClient::USER_AGENT}"
       @default_headers = {
-        'Content-Type' => 'application/json',
         'User-Agent' => @user_agent
       }
       @default_headers['Accept-Encoding'] = 'gzip' if @config.compress
@@ -340,10 +339,7 @@ module DatadogAPIClient::V2
     # @param [Array] accepts array for Accept
     # @return [String] the Accept header (e.g. application/json)
     def select_header_accept(accepts)
-      return nil if accepts.nil? || accepts.empty?
-      # use JSON when present, otherwise use all of the provided
-      json_accept = accepts.find { |s| json_mime?(s) }
-      json_accept || accepts.join(',')
+      accepts.join(', ')
     end
 
     # Return Content-Type header based on an array of content types provided.

--- a/lib/datadog_api_client/v2/api_client.rb
+++ b/lib/datadog_api_client/v2/api_client.rb
@@ -339,6 +339,7 @@ module DatadogAPIClient::V2
     # @param [Array] accepts array for Accept
     # @return [String] the Accept header (e.g. application/json)
     def select_header_accept(accepts)
+      return nil if accepts.nil? || accepts.empty?
       accepts.join(', ')
     end
 

--- a/spec/v1/api_client_spec.rb
+++ b/spec/v1/api_client_spec.rb
@@ -169,11 +169,11 @@ describe DatadogAPIClient::V1::APIClient do
       expect(api_client.select_header_accept([])).to be_nil
 
       expect(api_client.select_header_accept(['application/json'])).to eq('application/json')
-      expect(api_client.select_header_accept(['application/xml', 'application/json; charset=UTF8'])).to eq('application/json; charset=UTF8')
-      expect(api_client.select_header_accept(['APPLICATION/JSON', 'text/html'])).to eq('APPLICATION/JSON')
+      expect(api_client.select_header_accept(['application/xml', 'application/json; charset=UTF8'])).to eq('application/xml, application/json; charset=UTF8')
+      expect(api_client.select_header_accept(['APPLICATION/JSON', 'text/html'])).to eq('APPLICATION/JSON, text/html')
 
       expect(api_client.select_header_accept(['application/xml'])).to eq('application/xml')
-      expect(api_client.select_header_accept(['text/html', 'application/xml'])).to eq('text/html,application/xml')
+      expect(api_client.select_header_accept(['text/html', 'application/xml'])).to eq('text/html, application/xml')
     end
   end
 

--- a/spec/v2/api_client_spec.rb
+++ b/spec/v2/api_client_spec.rb
@@ -169,11 +169,11 @@ describe DatadogAPIClient::V2::APIClient do
       expect(api_client.select_header_accept([])).to be_nil
 
       expect(api_client.select_header_accept(['application/json'])).to eq('application/json')
-      expect(api_client.select_header_accept(['application/xml', 'application/json; charset=UTF8'])).to eq('application/json; charset=UTF8')
-      expect(api_client.select_header_accept(['APPLICATION/JSON', 'text/html'])).to eq('APPLICATION/JSON')
+      expect(api_client.select_header_accept(['application/xml', 'application/json; charset=UTF8'])).to eq('application/xml, application/json; charset=UTF8')
+      expect(api_client.select_header_accept(['APPLICATION/JSON', 'text/html'])).to eq('APPLICATION/JSON, text/html')
 
       expect(api_client.select_header_accept(['application/xml'])).to eq('application/xml')
-      expect(api_client.select_header_accept(['text/html', 'application/xml'])).to eq('text/html,application/xml')
+      expect(api_client.select_header_accept(['text/html', 'application/xml'])).to eq('text/html, application/xml')
     end
   end
 


### PR DESCRIPTION
Enable header matching against cassettes, and fix multiple headers
management in the client.