### PR TITLE
Remove datadog-ci git-metadata upload

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -49,13 +49,6 @@ jobs:
           repo: datadog-api-spec
           status: pending
           context: integration
-      - name: Report source code metadata
-        run: |
-          curl -L "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output ./datadog-ci
-          chmod +x "./datadog-ci"
-          ./datadog-ci git-metadata upload
-        env:
-          DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
       - name: Set up Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Remove `datadog-ci git-metadata upload` that sends git metadata as it's not required by #source-code-integration anymore.