### PR TITLE
Configure Zeitwerk with absolute paths

### DIFF
--- a/lib/datadog_api_client.rb
+++ b/lib/datadog_api_client.rb
@@ -3,9 +3,9 @@ require_relative 'datadog_api_client/inflector'
 
 loader = Zeitwerk::Loader.new
 loader.tag = File.basename(__FILE__, ".rb")
-loader.collapse("lib/datadog_api_client/*/models/")
-loader.collapse("lib/datadog_api_client/*/api/")
-loader.push_dir("lib/datadog_api_client/v1", namespace: DatadogAPIClient::V1)
-loader.push_dir("lib/datadog_api_client/v2", namespace: DatadogAPIClient::V2)
+loader.collapse("#{__dir__}/datadog_api_client/*/models/")
+loader.collapse("#{__dir__}/datadog_api_client/*/api/")
+loader.push_dir("#{__dir__}/datadog_api_client/v1", namespace: DatadogAPIClient::V1)
+loader.push_dir("#{__dir__}/datadog_api_client/v2", namespace: DatadogAPIClient::V2)
 loader.inflector = DatadogAPIClient::DatadogAPIClientInflector.new
 loader.setup


### PR DESCRIPTION
### What does this PR do?

The latest `2.0.0` release seems to be broken and unable to load the gem because Zeitwerk is trying to load the gem files from the working directory. This PR makes the paths absolute (as the [Zeitwerk README](https://github.com/fxn/zeitwerk/blob/main/README.md#root-directories-and-root-namespaces) suggests)

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x ] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
