### PR TITLE
Allow configuration via the version modules

### DIFF
--- a/lib/datadog_api_client/models.rb
+++ b/lib/datadog_api_client/models.rb
@@ -21,9 +21,9 @@ require 'datadog_api_client/configuration'
 require 'datadog_api_client/api_key_configuration'
 
 # Model base
-## Load in the model_base modules which also initializes the V1 and V2 namespaces
-require 'datadog_api_client/v1/model_base'
-require 'datadog_api_client/v2/model_base'
+## Load in the version modules which also initializes the V1 and V2 namespaces
+require 'datadog_api_client/v1'
+require 'datadog_api_client/v2'
 
 module DatadogAPIClient
   class << self

--- a/lib/datadog_api_client/v1.rb
+++ b/lib/datadog_api_client/v1.rb
@@ -1,6 +1,6 @@
-require_relative 'v2/model_base'
+require_relative 'v1/model_base'
 
-module DatadogAPIClient::V2
+module DatadogAPIClient::V1
   class << self
     def configure(&block)
       DatadogAPIClient.configure(&block)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -42,4 +42,28 @@ describe DatadogAPIClient::Configuration do
       end
     end
   end
+
+  describe "DatadogAPIClient.configure" do
+    it 'can be called' do
+      DatadogAPIClient.configure do |config|
+        expect(config).to be_a(DatadogAPIClient::Configuration)
+      end
+    end
+  end
+
+  describe "DatadogAPIClient::V1.configure" do
+    it 'can be called' do
+      DatadogAPIClient::V1.configure do |config|
+        expect(config).to be_a(DatadogAPIClient::Configuration)
+      end
+    end
+  end
+
+  describe "DatadogAPIClient::V2.configure" do
+    it 'can be called' do
+      DatadogAPIClient::V2.configure do |config|
+        expect(config).to be_a(DatadogAPIClient::Configuration)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

This allows configuration of the gem via the `DatadogAPIClient::V1` and ` DatadogAPIClient::V2` modules as the readme is suggesting. It seemed that the original `v2.rb` file was never loaded on initialization.

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
