### PR TITLE
Don't try to load model_base on eager_load

### DIFF
--- a/lib/datadog_api_client.rb
+++ b/lib/datadog_api_client.rb
@@ -7,5 +7,7 @@ loader.collapse("#{__dir__}/datadog_api_client/*/models/")
 loader.collapse("#{__dir__}/datadog_api_client/*/api/")
 loader.push_dir("#{__dir__}/datadog_api_client/v1", namespace: DatadogAPIClient::V1)
 loader.push_dir("#{__dir__}/datadog_api_client/v2", namespace: DatadogAPIClient::V2)
+# Ignore model_base.rb from being loaded in by zeitwerk as it is loaded in by default
+loader.ignore("#{__dir__}/datadog_api_client/*/model_base.rb")
 loader.inflector = DatadogAPIClient::DatadogAPIClientInflector.new
 loader.setup


### PR DESCRIPTION
Closes: https://github.com/DataDog/datadog-api-client-ruby/issues/1016

zeitwerk gem tries to load in `ModelBase` from `model_base.rb` on eager load. This file should be ignored as it is loaded in by default to initialize the namespaces and base models.