### PR TITLE
Pin msgpack version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :development, :test do
   gem 'vcr'
   gem 'webmock'
   gem 'zstandard'
+  gem 'msgpack', '1.5.4'
 end
 
 group :docs do


### PR DESCRIPTION
Looks like latest 1.5.5 release is breaking jruby test build. Pin the `msgpack` gem for now. The gem seems to be used by ddtrace