### PR TITLE
Fix additionalProperties handling in some examples

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -336,6 +336,8 @@ def format_data_with_schema_dict(
                 replace_values=replace_values,
             )
             parameters += f"{k}: {value}, "
+        if not has_properties:
+            name = None
 
     if not name and "oneOf" not in schema:
         if default_name and not schema.get("additionalProperties") and schema.get("properties"):

--- a/examples/v1/service-level-objectives/DeleteSLOTimeframeInBulk.rb
+++ b/examples/v1/service-level-objectives/DeleteSLOTimeframeInBulk.rb
@@ -3,7 +3,7 @@
 require "datadog_api_client"
 api_instance = DatadogAPIClient::V1::ServiceLevelObjectivesAPI.new
 
-body = DatadogAPIClient::V1::SLOBulkDelete.new({
+body = {
   id1: [
     DatadogAPIClient::V1::SLOTimeframe::SEVEN_DAYS,
     DatadogAPIClient::V1::SLOTimeframe::THIRTY_DAYS,
@@ -11,5 +11,5 @@ body = DatadogAPIClient::V1::SLOBulkDelete.new({
     DatadogAPIClient::V1::SLOTimeframe::SEVEN_DAYS,
     DatadogAPIClient::V1::SLOTimeframe::THIRTY_DAYS,
   ],
-})
+}
 p api_instance.delete_slo_timeframe_in_bulk(body)

--- a/examples/v1/synthetics/CreateSyntheticsAPITest_1402674167.rb
+++ b/examples/v1/synthetics/CreateSyntheticsAPITest_1402674167.rb
@@ -18,7 +18,7 @@ body = DatadogAPIClient::V1::SyntheticsAPITest.new({
       service: "Hello",
       method: DatadogAPIClient::V1::HTTPMethod::GET,
       message: "",
-      metadata: DatadogAPIClient::V1::SyntheticsTestMetadata.new({}),
+      metadata: {},
     }),
   }),
   locations: [

--- a/examples/v1/synthetics/CreateSyntheticsAPITest_1487281163.rb
+++ b/examples/v1/synthetics/CreateSyntheticsAPITest_1487281163.rb
@@ -48,15 +48,15 @@ body = DatadogAPIClient::V1::SyntheticsAPITest.new({
           updated_at: "2020-10-16T09:23:24.857Z",
         }),
       }),
-      headers: DatadogAPIClient::V1::SyntheticsTestHeaders.new({
+      headers: {
         unique: "examplecreateanapihttptestreturnsokreturnsthecreatedtestdetailsresponse",
-      }),
+      },
       method: DatadogAPIClient::V1::HTTPMethod::GET,
       timeout: 10,
       url: "https://datadoghq.com",
       proxy: DatadogAPIClient::V1::SyntheticsTestRequestProxy.new({
         url: "https://datadoghq.com",
-        headers: DatadogAPIClient::V1::SyntheticsTestHeaders.new({}),
+        headers: {},
       }),
     }),
   }),

--- a/examples/v1/synthetics/UpdateAPITest.rb
+++ b/examples/v1/synthetics/UpdateAPITest.rb
@@ -49,9 +49,9 @@ body = DatadogAPIClient::V1::SyntheticsAPITest.new({
           updated_at: "2020-10-16T09:23:24.857Z",
         }),
       }),
-      headers: DatadogAPIClient::V1::SyntheticsTestHeaders.new({
+      headers: {
         unique: "exampleeditanapitestreturnsokresponse",
-      }),
+      },
       method: DatadogAPIClient::V1::HTTPMethod::GET,
       timeout: 10,
       url: "https://datadoghq.com",


### PR DESCRIPTION
We don't generate a model when there are only addionalProperties, so we can't use them in examples.