### PR TITLE
Skip ddtrace profiling extension

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DD_PROFILING_NO_EXTENSION: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
     if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')
     env:
       BUNDLE_WITHOUT: docs
-      DD_PROFILING_NO_EXTENSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -99,6 +98,8 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')
+    env:
+      DD_PROFILING_NO_EXTENSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
     if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')
     env:
       BUNDLE_WITHOUT: docs
+      DD_PROFILING_NO_EXTENSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
CI is failing due to the install of ddtrace failing. The install failure happens when building the extension, so this PR is for temporarily skipping the extension while apm-ruby investigates the root cause of the install failure.