### PR TITLE
disable ddtrace ruby profiling extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
     if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')
     env:
       BUNDLE_WITHOUT: docs
+      DD_PROFILING_NO_EXTENSION: true
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
dd-trace-ruby 1.6.1 failing on building the extension, which we don't use. This disables the extension in tests.