### PR TITLE
Don't raise error on unhandled keys

### DIFF
--- a/.generator/src/generator/templates/model_base.j2
+++ b/.generator/src/generator/templates/model_base.j2
@@ -239,8 +239,6 @@ module {{ module_name }}::{{ version|upper }}
             model = const.build(data)
             return model if model
           else
-            # raise if data contains keys that are not known to the model
-            raise unless (data.keys - const.attribute_map.values).empty?
             model = const.build_from_hash(data)
             return model if model && model.valid?
           end

--- a/lib/datadog_api_client/v1/model_base.rb
+++ b/lib/datadog_api_client/v1/model_base.rb
@@ -250,8 +250,6 @@ module DatadogAPIClient::V1
             model = const.build(data)
             return model if model
           else
-            # raise if data contains keys that are not known to the model
-            raise unless (data.keys - const.attribute_map.values).empty?
             model = const.build_from_hash(data)
             return model if model && model.valid?
           end

--- a/lib/datadog_api_client/v2/model_base.rb
+++ b/lib/datadog_api_client/v2/model_base.rb
@@ -250,8 +250,6 @@ module DatadogAPIClient::V2
             model = const.build(data)
             return model if model
           else
-            # raise if data contains keys that are not known to the model
-            raise unless (data.keys - const.attribute_map.values).empty?
             model = const.build_from_hash(data)
             return model if model && model.valid?
           end


### PR DESCRIPTION
Adding a new field is backward compatible change, we shouldn't raise errors in that case.