### PR TITLE
Clarify readme example for how to send data to another site

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ When talking to a different server, like the `eu` instance, change the `server_v
 
 ```ruby
 config = DatadogAPIClient::Configuration.new
-config.server_variables["site"] = "datadoghq.eu"
+config.server_variables[:site] = "datadoghq.eu"
 client = DatadogAPIClient::APIClient.new(config)
 ```
 


### PR DESCRIPTION
It turns out that string keys parameters on the server_variables doesn't work to update the site, it has to be a symbol key.

<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?
Fixes the README example for how to send data to another site, such as EU1.

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature."
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
We ran into an issue on our side where we were unable to get metric sending to work in EU1. Changing from string keys to symbol keys fixed it. There are two examples in the README, one with string and one with symbol keys. 

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
