### PR TITLE
#1290 - Set the most recent Ruby for unit tests to 3.2.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ["2.6", "3.1", "jruby"]
+        ruby-version: ["2.6", "3.2", "jruby"]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) || github.event_name == 'schedule'


### PR DESCRIPTION
### What does this PR do?

Replaces Ruby 3.1 with Ruby 3.2 in the unit test configuration.  Partially addresses #1290 

### Additional Notes

Unit tests run green on my fork.

### Review checklist

Please check relevant items below:

- [X] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [X] This PR does not rely on API client schema changes.
  - [X] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
