### PR TITLE
Fix for inflection when your absolute filepath happens to match `v[0-9]`

### DIFF
--- a/.generator/src/generator/templates/inflector.j2
+++ b/.generator/src/generator/templates/inflector.j2
@@ -3,7 +3,7 @@ require 'zeitwerk'
 module {{ module_name }}
   class {{ module_name }}Inflector < Zeitwerk::Inflector
     def camelize(basename, abspath)
-      model_name = "#{abspath.match('v[0-9]')}.#{basename}"
+      model_name = "#{abspath.scan(/v[0-9]/).last}.#{basename}"
       overrides[model_name] || basename.split('_').each(&:capitalize!).join
     end
 

--- a/lib/datadog_api_client/inflector.rb
+++ b/lib/datadog_api_client/inflector.rb
@@ -3,7 +3,7 @@ require 'zeitwerk'
 module DatadogAPIClient
   class DatadogAPIClientInflector < Zeitwerk::Inflector
     def camelize(basename, abspath)
-      model_name = "#{abspath.match('v[0-9]')}.#{basename}"
+      model_name = "#{abspath.scan(/v[0-9]/).last}.#{basename}"
       overrides[model_name] || basename.split('_').each(&:capitalize!).join
     end
 


### PR DESCRIPTION
### What does this PR do?

Fix for inflection when your absolute filepath happens to match `v[0-9]` in the parent structure. This can happen on nix.

For example, with a filepath of:

    /nix/store/xdav9lnh1idxynnqayfr3dclm4i2dmq3-ruby3.2.2-datadog_api_client-2.10.0/lib/ruby/gems/3.2.0/gems/datadog_api_client-2.10.0/lib/datadog_api_client/v1/api/authentication_api.rb

You'll attempt to inflect AuthenticationAPI as AuthenticationApi, as we attempt to lookup an override of `"v9.authentication_api"`, which does not exist.

(Look closely: `xdav9lnh1idxynnqayfr3dclm4i2dmq3`) has `v9` in it.


### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
