### PR TITLE
Handle models with `v[0-9]` in name when loading them

### DIFF
--- a/.generator/src/generator/templates/inflector.j2
+++ b/.generator/src/generator/templates/inflector.j2
@@ -3,7 +3,7 @@ require 'zeitwerk'
 module {{ module_name }}
   class {{ module_name }}Inflector < Zeitwerk::Inflector
     def camelize(basename, abspath)
-      model_name = "#{abspath.scan(/v[0-9]/).last}.#{basename}"
+      model_name = "#{abspath.match(/datadog_api_client\/(v[0-9])\//)&.captures&.first}.#{basename}"
       overrides[model_name] || basename.split('_').each(&:capitalize!).join
     end
 

--- a/lib/datadog_api_client/inflector.rb
+++ b/lib/datadog_api_client/inflector.rb
@@ -3,7 +3,7 @@ require 'zeitwerk'
 module DatadogAPIClient
   class DatadogAPIClientInflector < Zeitwerk::Inflector
     def camelize(basename, abspath)
-      model_name = "#{abspath.scan(/v[0-9]/).last}.#{basename}"
+      model_name = "#{abspath.match(/datadog_api_client\/(v[0-9])\//)&.captures&.first}.#{basename}"
       overrides[model_name] || basename.split('_').each(&:capitalize!).join
     end
 

--- a/spec/zeitwerk_spec.rb
+++ b/spec/zeitwerk_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'zeitwerk loader' do
+    it "should load all files" do
+        expect { Zeitwerk::Loader.eager_load_all }.not_to raise_error
+    end
+end


### PR DESCRIPTION
Previous implementation did not support models such as:
```
datadog_api_client/v2/models/entity_v3.rb
```
Since it was looking for the last occurrence of the regex `/v[0-9]/`.

This PR safe guards against such cases in the future and ensures we are explicitly looking for `datadog_api_client\/(v[0-9])\/`

Closes: https://github.com/DataDog/datadog-api-client-ruby/issues/1991