### PR TITLE
Fix SubmitDistributionPoints examples

### DIFF
--- a/examples/v1/metrics/SubmitDistributionPoints.rb
+++ b/examples/v1/metrics/SubmitDistributionPoints.rb
@@ -9,7 +9,7 @@ body = DatadogAPIClient::V1::DistributionPointsPayload.new({
       metric: "system.load.1.dist",
       points: [
         [
-          Time.now,
+          Time.now.to_f,
           [
             1.0,
             2.0,

--- a/examples/v1/metrics/SubmitDistributionPoints_3109558960.rb
+++ b/examples/v1/metrics/SubmitDistributionPoints_3109558960.rb
@@ -9,7 +9,7 @@ body = DatadogAPIClient::V1::DistributionPointsPayload.new({
       metric: "system.load.1.dist",
       points: [
         [
-          Time.now,
+          Time.now.to_f,
           [
             1.0,
             2.0,


### PR DESCRIPTION
<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

The [Ruby examples to submit distribution metrics](https://docs.datadoghq.com/api/latest/metrics/?code-lang=ruby#submit-distribution-points) fail because the timestamp is not submitted as posix timestamp.

```
❯ ruby example.rb
/Users/tim/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/datadog_api_client-2.26.1/lib/datadog_api_client/api_client.rb:118:in `block in call_api': Error message: the server returns an error (DatadogAPIClient::APIError)
HTTP status code: 400
Response headers: {"date"=>["Fri, 13 Sep 2024 20:39:25 GMT"], "content-type"=>["text/plain; charset=utf-8"], "content-length"=>["98"], "connection"=>["close"], "x-content-type-options"=>["nosniff"], "strict-transport-security"=>["max-age=31536000; includeSubDomains; preload"]}
Response body: Payload is not in the expected format: json: cannot unmarshal string into Go value of type float64
        from /Users/tim/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/datadog_api_client-2.26.1/lib/datadog_api_client/api_client.rb:59:in `loop'
        from /Users/tim/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/datadog_api_client-2.26.1/lib/datadog_api_client/api_client.rb:59:in `call_api'
        from /Users/tim/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/datadog_api_client-2.26.1/lib/datadog_api_client/v1/api/metrics_api.rb:371:in `submit_distribution_points_with_http_info'
        from /Users/tim/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/datadog_api_client-2.26.1/lib/datadog_api_client/v1/api/metrics_api.rb:309:in `submit_distribution_points'
        from example.rb:32:in `<main>'
```

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature."
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
