### PR TITLE
ci(workflows): fix use of create-github-app-token repositories

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: DataDog/datadog-api-spec
+          repositories: datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: DataDog/datadog-api-spec
+          repositories: datadog-api-spec
       - name: Post status 3heck
         uses: DataDog/github-actions/post-status-check@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: datadog-api-spec
+          repositories:  datadog-api-spec
       - name: Post status 3heck
         uses: DataDog/github-actions/post-status-check@v2
         with:

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: DataDog/datadog-api-spec
+          repositories: datadog-api-spec
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Post pending status check


### PR DESCRIPTION
### What does this PR do?

- fixes use of `repositories` field for `create-github-app-token`
