### PR TITLE
Always run test_integration job to satisfy required branch check

### DIFF
--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -65,14 +65,6 @@ concurrency:
 jobs:
   test_integration:
     runs-on: ubuntu-latest
-    if: >
-      (github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false &&
-      !contains(github.event.pull_request.labels.*.name, 'ci/skip') &&
-      !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/') &&
-      contains(github.event.pull_request.labels.*.name, 'ci/integrations')) ||
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_call' && inputs.has-integration-label)
     services:
       datadog-agent:
         image: gcr.io/datadoghq/agent:latest
@@ -86,20 +78,25 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Check if integration tests should run
+        id: check
+        run: |
+          echo "should_run=${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/') && contains(github.event.pull_request.labels.*.name, 'ci/integrations')) || github.event_name == 'schedule' || (github.event_name == 'workflow_call' && inputs.has-integration-label) }}" >> $GITHUB_OUTPUT
       - name: Get GitHub App token
-        if: github.event_name == 'pull_request'
+        if: steps.check.outputs.should_run == 'true' && github.event_name == 'pull_request'
         id: get_token
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-ruby.reusable-integration-test.post-status
       - name: Checkout code
+        if: steps.check.outputs.should_run == 'true'
         uses: actions/checkout@v3
         with:
           repository: DataDog/datadog-api-client-ruby
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Post pending status check
-        if: github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
+        if: steps.check.outputs.should_run == 'true' && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
         uses: DataDog/github-actions/post-status-check@v2
         with:
           github-token: ${{ steps.get_token.outputs.token }}
@@ -107,18 +104,22 @@ jobs:
           status: pending
           context: ${{ inputs.status-context || 'integration' }}
       - name: Install system zstd
+        if: steps.check.outputs.should_run == 'true'
         run: |
           sudo apt-get -y install zstd
           echo "ZSTANDARD_LIBRARY=$(find /usr/lib -iname libzstd.so.1)" >> $GITHUB_ENV
       - name: Set up Ruby 3.2
+        if: steps.check.outputs.should_run == 'true'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
           bundler-cache: true
           cache-version: ${{ inputs.cache-version }}
       - name: Install deps
+        if: steps.check.outputs.should_run == 'true'
         run: bundle install
       - name: Run integration tests
+        if: steps.check.outputs.should_run == 'true'
         run: ./run-tests.sh
         shell: bash
         env:
@@ -133,7 +134,7 @@ jobs:
           RECORD: "none"
           SLEEP_AFTER_REQUEST: ${{ secrets.SLEEP_AFTER_REQUEST || vars.SLEEP_AFTER_REQUEST }}
       - name: Post failure status check
-        if: failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
+        if: steps.check.outputs.should_run == 'true' && failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
         uses: DataDog/github-actions/post-status-check@v2
         with:
           github-token: ${{ steps.get_token.outputs.token }}
@@ -141,7 +142,7 @@ jobs:
           status: failure
           context: ${{ inputs.status-context || 'integration' }}
       - name: Post success status check
-        if: "!failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')"
+        if: steps.check.outputs.should_run == 'true' && !failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
         uses: DataDog/github-actions/post-status-check@v2
         with:
           github-token: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
## Problem

The `test_integration` job in `reusable-integration-test.yml` has a top-level `if` condition that skips the entire job when the `ci/integrations` label is absent. When the job is skipped, the required branch protection check `test_integration` is never reported, permanently blocking PRs from being merged.

This affects all generated PRs (branches like `datadog-api-spec/generated/*`) that don't have the `ci/integrations` label.

## Fix

- Remove the job-level `if` condition so the job always runs and the check is always reported
- Add a first step (`Check if integration tests should run`) that evaluates the same condition and sets a `should_run` output
- Gate all substantive steps on `steps.check.outputs.should_run == 'true'`

When integration tests are not needed, the job runs but all steps after the check are skipped — GitHub reports the job as **success**, satisfying the required check without running the actual tests.

## Behaviour unchanged

- Integration tests still only run when `ci/integrations` label is present (or on schedule/workflow_call with the flag)
- Status reporting back to datadog-api-spec still works the same way