### PR TITLE
Pin all remaining workflow actions to full commit SHAs

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -32,7 +32,7 @@ jobs:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-ruby.approved_status.post-review-status
       - name: Post PR review status check
-        uses: DataDog/github-actions/post-review-status@v2
+        uses: DataDog/github-actions/post-review-status@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: datadog-api-spec

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,11 +29,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@cdcdbb579706841c47f7063dda365e292e5cad7a # v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a # v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,13 @@ jobs:
       DD_PROFILING_NO_EXTENSION: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Fetch all history for applying timestamps to every page
           fetch-depth: 0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
         with:
           ruby-version: "2.7"
           bundler-cache: true
@@ -32,7 +32,7 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Cache yardoc
-        uses: actions/cache@v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             .yardoc
@@ -48,7 +48,7 @@ jobs:
       - name: Compress docs
         run: tar czf doc.tar.gz doc
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: documentation
           path: doc.tar.gz
@@ -61,7 +61,7 @@ jobs:
       - build
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: documentation
           path: doc
@@ -69,7 +69,7 @@ jobs:
       - name: Uncompress docs
         run: tar xzf doc/doc.tar.gz && rm doc/doc.tar.gz
 
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: DataDog/labeler@glob-all
+      - uses: DataDog/labeler@5170395583c7f7ec92989fd24faffc5b6154b866 # glob-all
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >-


### PR DESCRIPTION
Pins all remaining @vX floating tag action references to full commit SHAs to satisfy the enterprise policy requiring pinned actions.