### PR TITLE
Pins the i18n gem to the 1.14.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'webmock'
   gem 'zstandard'
   gem 'pry'
+  gem 'i18n', '~> 1.14.0'
 end
 
 group :docs do


### PR DESCRIPTION
### What does this PR do?
Pins the `i18n` gem to the `1.14.x` series in the development/test group of the `Gemfile`:
```ruby
gem 'i18n', '~> 1.14.0'
```
### Motivation
`i18n` 1.15.0 was released with new Fiber-based config storage that calls `Fiber[:i18n_config]`. `Fiber.[]` / `Fiber.[]=` is a Ruby 3.2+ API, so on Rubies older than 3.2 — including the JRuby and CRuby versions used in this repo's CI — loading `active_support/i18n` immediately fails with:
```
NoMethodError: undefined method `[]' for Fiber:Class
  current = Fiber[:i18n_config] || self.config = I18n::Config.new
```