### PR TITLE
Pin simplecov to < 1.0.0 to fix test suite crash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'rspec-expectations'
   gem 'rubocop'
   gem 'rufo'
-  gem 'simplecov'
+  gem 'simplecov', '< 1.0.0'
   gem 'timecop'
   gem 'vcr'
   gem 'webmock'


### PR DESCRIPTION
## Summary

- `simplecov` 1.0.0 was released on 2026-07-12 and removed the `SimpleCov.running` method
- `datadog-ci ~> 1.11` (resolved to 1.34.0) calls `SimpleCov.running` in `deprecated_total_coverage_metric.rb` during test session teardown
- This causes the test suite to exit with code 3 **after all tests pass**, failing CI

## Fix

Pin `simplecov` to `< 1.0.0` until `datadog-ci` releases a version compatible with SimpleCov 1.x.

## Test plan

- [ ] CI passes (all test scenarios should pass, no post-test crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)