### PR TITLE
[AGV-1596] Add is_iac support to send X-Datadog-Managed-By header

### DIFF
--- a/.generator/src/generator/templates/api_client.j2
+++ b/.generator/src/generator/templates/api_client.j2
@@ -32,6 +32,7 @@ module {{ module_name }}
         'User-Agent' => @user_agent
       }
       @default_headers['Accept-Encoding'] = 'gzip' if @config.compress
+      @default_headers['X-Datadog-Managed-By'] = 'iac' if @config.is_iac
     end
 
     def self.default

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -86,6 +86,13 @@ module {{ module_name }}
     # Keep track of the unstable operations, and if they have been enabled
     attr_accessor :unstable_operations
 
+    # Set this to true to mark requests as originating from infrastructure-as-code (IaC) tooling.
+    # When enabled, the `X-Datadog-Managed-By: iac` header is sent with every request.
+    # Default to false.
+    #
+    # @return [true, false]
+    attr_accessor :is_iac
+
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.
@@ -170,6 +177,7 @@ module {{ module_name }}
       @cert_file = nil
       @key_file = nil
       @debugging = false
+      @is_iac = false
       @inject_format = false
       @force_ending_format = false
       @compress = true

--- a/lib/datadog_api_client/api_client.rb
+++ b/lib/datadog_api_client/api_client.rb
@@ -43,6 +43,7 @@ module DatadogAPIClient
         'User-Agent' => @user_agent
       }
       @default_headers['Accept-Encoding'] = 'gzip' if @config.compress
+      @default_headers['X-Datadog-Managed-By'] = 'iac' if @config.is_iac
     end
 
     def self.default

--- a/lib/datadog_api_client/configuration.rb
+++ b/lib/datadog_api_client/configuration.rb
@@ -97,6 +97,13 @@ module DatadogAPIClient
     # Keep track of the unstable operations, and if they have been enabled
     attr_accessor :unstable_operations
 
+    # Set this to true to mark requests as originating from infrastructure-as-code (IaC) tooling.
+    # When enabled, the `X-Datadog-Managed-By: iac` header is sent with every request.
+    # Default to false.
+    #
+    # @return [true, false]
+    attr_accessor :is_iac
+
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.
@@ -180,6 +187,7 @@ module DatadogAPIClient
       @cert_file = nil
       @key_file = nil
       @debugging = false
+      @is_iac = false
       @inject_format = false
       @force_ending_format = false
       @compress = true

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -73,6 +73,23 @@ describe DatadogAPIClient::APIClient do
     end
   end
 
+  describe 'is_iac header in #build_request' do
+    let(:config) { DatadogAPIClient::Configuration.new }
+
+    it 'is not sent by default' do
+      api_client = DatadogAPIClient::APIClient.new(config)
+      request = api_client.build_request(Net::HTTP::Get, '/test')
+      expect(request.options[:headers]).not_to have_key('X-Datadog-Managed-By')
+    end
+
+    it 'is sent when is_iac is enabled on the configuration' do
+      config.is_iac = true
+      api_client = DatadogAPIClient::APIClient.new(config)
+      request = api_client.build_request(Net::HTTP::Get, '/test')
+      expect(request.options[:headers]['X-Datadog-Managed-By']).to eq('iac')
+    end
+  end
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = DatadogAPIClient::APIClient.new


### PR DESCRIPTION
## Summary
- Adds `Configuration#is_iac` (default `false`), which when enabled sends the `X-Datadog-Managed-By: iac` header on all requests.
- Lets Datadog distinguish infrastructure-as-code API traffic from other client usage.
- Configured at client-creation time, e.g. `Configuration.new { |c| c.is_iac = true }`; existing constructors are unaffected.

## Test plan
- [x] New spec in `spec/api_client_spec.rb` covering header-off-by-default and header-set-when-enabled behavior
- [x] `bundle exec rspec`: 39 examples, 0 failures
- [x] `rubocop`: no new offenses

___All of the API generation is moving to a new repo. This PR may never be merged, but changes are present in [openapi-transformer#389](https://github.com/DataDog/openapi-transformer/pull/389)___

🤖 Generated with [Claude Code](https://claude.com/claude-code)