### PR TITLE
Release 2.59.1 without generated test assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.59.1/2026-09-03
+
+### Fixed
+* Exclude generated test assets from the published gem
+
 ## 2.59.0/2026-09-02
 
 ### Added

--- a/datadog_api_client.gemspec
+++ b/datadog_api_client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec", "~> 3.6", ">= 3.6.0"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|cassettes)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|cassettes|generated-test)/}) }
   spec.test_files    = `git ls-files -z spec/`.split("\x0")
   spec.executables   = []
   spec.require_paths = ["lib"]

--- a/lib/datadog_api_client/version.rb
+++ b/lib/datadog_api_client/version.rb
@@ -1,5 +1,5 @@
 # Define library version.
 
 module DatadogAPIClient
-  VERSION = '2.59.0'
+  VERSION = '2.59.1'
 end


### PR DESCRIPTION
## Summary

- exclude generated-test from the published gem
- bump the client version to 2.59.1
- document the packaging fix in the changelog

This fixes the RubyGems filename-limit failure in the 2.59.0 publish job:
https://github.com/DataDog/datadog-api-client-ruby/actions/runs/33643472132/job/100292140462

## Verification

- built datadog_api_client-2.59.1.gem successfully
- confirmed the built gem contains no generated-test paths
- confirmed the gemspec and version file pass Ruby syntax checks