### PR TITLE
Pin json below 3.0 to restore test compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'bigdecimal', '= 3.1.9'
   gem 'cucumber', '~> 9.2.1'
   gem 'datadog-ci', '~> 1.11'
+  gem 'json', '< 3.0.0'
   gem 'libddwaf', '= 1.18.0.0.1'
   gem 'gem-release'
   gem 'rake', '~> 13.0.1'


### PR DESCRIPTION
## Summary

- constrain the development and test bundle to json versions below 3.0
- avoid the json 3.0 removal of quirks_mode used by HTTParty 0.24.2
- continue allowing compatible 2.x security and bugfix releases

## Testing

- bundle check
- bundle exec rspec (39 examples, 0 failures)
- DD_USE_GENERATED_TESTS=true bundle exec cucumber features/v2/application_security.feature:208 (1 scenario, 0 failures)
- git diff --check

The regression was observed in https://github.com/DataDog/datadog-api-client-ruby/actions/runs/34121398026/job/101740023879?pr=3778.